### PR TITLE
유저 정보 저장, 토큰 발급 검증 기능 구현

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -26,3 +26,4 @@ replay_pid*
 .idea
 mods/*.zip
 application.yaml
+spring/db/

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -57,9 +57,7 @@ services:
 
     web:
         container_name: minecraft-web
-        build:
-            context: spring
-            dockerfile: Dockerfile
+        image: amazoncorretto:17-alpine
 #        ports: # Expose web server port, 그런데 저는 nginx를 사용해서 프록시를 설정할 예정입니다.
 #            - "80:80" # HTTP port
         expose:
@@ -68,10 +66,15 @@ services:
         networks:
             - nginx-proxy
             - mc-network
+        working_dir: /app
         volumes:
-            - ./spring:/app
+            - ./spring/libs/:/app
             - ./data:/app/data
             - ./mods:/app/mods
+        command:
+            - java
+            - -jar
+            - /app/minecraft-web.jar
 
 networks:
     mc-network:

--- a/spring/build.gradle
+++ b/spring/build.gradle
@@ -17,10 +17,23 @@ repositories {
 	mavenCentral()
 }
 
+bootJar {
+	archiveBaseName = 'app'
+	archiveVersion = ''
+	archiveClassifier = ''
+}
+
 dependencies {
 	implementation 'org.springframework.boot:spring-boot-starter-jdbc'
 	implementation 'org.springframework.boot:spring-boot-starter-thymeleaf'
+	implementation 'org.springframework.boot:spring-boot-starter-web'
+	implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
+	implementation 'org.projectlombok:lombok'
+	implementation 'jakarta.validation:jakarta.validation-api:3.0.2'
+	implementation 'org.hibernate.validator:hibernate-validator:8.0.1.Final'
+	annotationProcessor 'org.projectlombok:lombok'
 	testImplementation 'org.springframework.boot:spring-boot-starter-test'
+	runtimeOnly 'com.h2database:h2'
 	testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
 }
 

--- a/spring/src/main/java/mcserver/spring/Application.java
+++ b/spring/src/main/java/mcserver/spring/Application.java
@@ -2,12 +2,12 @@ package mcserver.spring;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
 
 @SpringBootApplication
+@EnableJpaAuditing
 public class Application {
-
 	public static void main(String[] args) {
 		SpringApplication.run(Application.class, args);
 	}
-
 }

--- a/spring/src/main/java/mcserver/spring/common/annotation/RequireInternalHeader.java
+++ b/spring/src/main/java/mcserver/spring/common/annotation/RequireInternalHeader.java
@@ -1,0 +1,13 @@
+package mcserver.spring.common.annotation;
+
+import java.lang.annotation.Documented;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Target({ElementType.METHOD, ElementType.TYPE})
+@Retention(RetentionPolicy.RUNTIME)
+@Documented
+public @interface RequireInternalHeader {
+}

--- a/spring/src/main/java/mcserver/spring/common/config/WebConfig.java
+++ b/spring/src/main/java/mcserver/spring/common/config/WebConfig.java
@@ -1,0 +1,19 @@
+package mcserver.spring.common.config;
+
+import mcserver.spring.common.interceptor.InternalRequestInterceptor;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.servlet.config.annotation.InterceptorRegistry;
+import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
+
+@Configuration
+public class WebConfig implements WebMvcConfigurer {
+    private final InternalRequestInterceptor interceptor;
+
+    public WebConfig(InternalRequestInterceptor interceptor) {
+        this.interceptor = interceptor;
+    }
+
+    public void addInterceptors(InterceptorRegistry registry) {
+        registry.addInterceptor(this.interceptor).addPathPatterns(new String[]{"/**"});
+    }
+}

--- a/spring/src/main/java/mcserver/spring/common/interceptor/InternalRequestInterceptor.java
+++ b/spring/src/main/java/mcserver/spring/common/interceptor/InternalRequestInterceptor.java
@@ -1,0 +1,31 @@
+package mcserver.spring.common.interceptor;
+
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import mcserver.spring.common.annotation.RequireInternalHeader;
+import org.springframework.stereotype.Component;
+import org.springframework.web.method.HandlerMethod;
+import org.springframework.web.servlet.HandlerInterceptor;
+
+@Component
+public class InternalRequestInterceptor implements HandlerInterceptor {
+    public boolean preHandle(HttpServletRequest request, HttpServletResponse response, Object handler) throws Exception {
+        if (handler instanceof HandlerMethod method) {
+            RequireInternalHeader annotation = (RequireInternalHeader)method.getMethodAnnotation(RequireInternalHeader.class);
+            if (annotation == null) {
+                annotation = (RequireInternalHeader)method.getBeanType().getAnnotation(RequireInternalHeader.class);
+            }
+
+            if (annotation != null) {
+                String header = request.getHeader("X-Internal-Request");
+                if (header == null || header.isBlank() || !header.equals("true")) {
+                    response.setStatus(402);
+                    response.getWriter().write("Missing X-Internal-Request header");
+                    return false;
+                }
+            }
+        }
+
+        return true;
+    }
+}

--- a/spring/src/main/java/mcserver/spring/common/model/BaseEntity.java
+++ b/spring/src/main/java/mcserver/spring/common/model/BaseEntity.java
@@ -1,0 +1,46 @@
+package mcserver.spring.common.model;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.EntityListeners;
+import jakarta.persistence.MappedSuperclass;
+import java.time.LocalDateTime;
+import lombok.Generated;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.annotation.LastModifiedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+@MappedSuperclass
+@EntityListeners({AuditingEntityListener.class})
+public abstract class BaseEntity {
+    @CreatedDate
+    @Column(
+            nullable = false,
+            updatable = false
+    )
+    private LocalDateTime createdAt;
+    @LastModifiedDate
+    @Column(
+            nullable = false
+    )
+    private LocalDateTime updatedAt;
+
+    @Generated
+    public LocalDateTime getCreatedAt() {
+        return this.createdAt;
+    }
+
+    @Generated
+    public LocalDateTime getUpdatedAt() {
+        return this.updatedAt;
+    }
+
+    @Generated
+    public void setCreatedAt(final LocalDateTime createdAt) {
+        this.createdAt = createdAt;
+    }
+
+    @Generated
+    public void setUpdatedAt(final LocalDateTime updatedAt) {
+        this.updatedAt = updatedAt;
+    }
+}

--- a/spring/src/main/java/mcserver/spring/user/controller/DiscordUserController.java
+++ b/spring/src/main/java/mcserver/spring/user/controller/DiscordUserController.java
@@ -1,0 +1,54 @@
+package mcserver.spring.user.controller;
+
+import mcserver.spring.common.annotation.RequireInternalHeader;
+import mcserver.spring.user.dto.token.TokenResult;
+import mcserver.spring.user.dto.user.UserRequest;
+import mcserver.spring.user.dto.user.UserResult;
+import mcserver.spring.user.model.DiscordUser;
+import mcserver.spring.user.model.Token;
+import mcserver.spring.user.service.DiscordUserService;
+import mcserver.spring.user.service.TokenService;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping({"/api/users"})
+@RequireInternalHeader
+public class DiscordUserController {
+    private final DiscordUserService userService;
+    private final TokenService tokenService;
+
+    public DiscordUserController(DiscordUserService userService, TokenService tokenService) {
+        this.userService = userService;
+        this.tokenService = tokenService;
+    }
+
+    @PostMapping({"/register"})
+    public ResponseEntity<UserResult> register(@RequestBody UserRequest request) {
+        DiscordUser user = this.userService.register(request);
+        return ResponseEntity.ok(UserResult.from(user));
+    }
+
+    @PostMapping({"/update"})
+    public ResponseEntity<UserResult> update(@RequestBody UserRequest request) {
+        DiscordUser user = this.userService.updateDiscordUser(request);
+        return ResponseEntity.ok(UserResult.from(user));
+    }
+
+    @GetMapping({"/{id}"})
+    public ResponseEntity<UserResult> getUser(@PathVariable Long id) {
+        DiscordUser user = this.userService.getById(id);
+        return ResponseEntity.ok(UserResult.from(user));
+    }
+
+    @PostMapping({"/{id}/token"})
+    public ResponseEntity<TokenResult> updateToken(@PathVariable Long id) {
+        Token token = this.tokenService.getToken(id);
+        return ResponseEntity.ok(TokenResult.from(token));
+    }
+}

--- a/spring/src/main/java/mcserver/spring/user/dto/token/TokenRequest.java
+++ b/spring/src/main/java/mcserver/spring/user/dto/token/TokenRequest.java
@@ -1,0 +1,4 @@
+package mcserver.spring.user.dto.token;
+
+public class TokenRequest {
+}

--- a/spring/src/main/java/mcserver/spring/user/dto/token/TokenResult.java
+++ b/spring/src/main/java/mcserver/spring/user/dto/token/TokenResult.java
@@ -1,0 +1,9 @@
+package mcserver.spring.user.dto.token;
+
+import mcserver.spring.user.model.Token;
+
+public record TokenResult(String token) {
+    public static TokenResult from(Token token) {
+        return new TokenResult(token.getToken());
+    }
+}

--- a/spring/src/main/java/mcserver/spring/user/dto/user/UserRequest.java
+++ b/spring/src/main/java/mcserver/spring/user/dto/user/UserRequest.java
@@ -1,0 +1,7 @@
+package mcserver.spring.user.dto.user;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+
+public record UserRequest(@NotNull Long discordId, @NotBlank String userName, String minecraftName) {
+}

--- a/spring/src/main/java/mcserver/spring/user/dto/user/UserResult.java
+++ b/spring/src/main/java/mcserver/spring/user/dto/user/UserResult.java
@@ -1,0 +1,9 @@
+package mcserver.spring.user.dto.user;
+
+import mcserver.spring.user.model.DiscordUser;
+
+public record UserResult(Long discordId, String userName, String minecraftName) {
+    public static UserResult from(DiscordUser user) {
+        return new UserResult(user.getDiscordId(), user.getUserName(), user.getMinecraftName());
+    }
+}

--- a/spring/src/main/java/mcserver/spring/user/model/DiscordUser.java
+++ b/spring/src/main/java/mcserver/spring/user/model/DiscordUser.java
@@ -1,0 +1,23 @@
+package mcserver.spring.user.model;
+
+import jakarta.persistence.*;
+import lombok.*;
+import mcserver.spring.common.model.BaseEntity;
+
+@Entity
+@Table(name = "discord_users")
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+public class DiscordUser extends BaseEntity {
+    @Id
+    @Column(name = "discord_id", nullable = false, unique = true, updatable = false)
+    private Long discordId;
+
+    @Column(name = "discord_name", nullable = false)
+    private String userName;
+
+    @Column(name = "minecraft_name", nullable = true)
+    private String minecraftName;
+}

--- a/spring/src/main/java/mcserver/spring/user/model/Token.java
+++ b/spring/src/main/java/mcserver/spring/user/model/Token.java
@@ -1,0 +1,31 @@
+package mcserver.spring.user.model;
+
+import jakarta.persistence.*;
+import lombok.*;
+import mcserver.spring.common.model.BaseEntity;
+import mcserver.spring.user.util.TokenGenerator;
+
+@Entity
+@Table(name = "tokens")
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+public class Token extends BaseEntity {
+    @Id
+    @Column(name = "discord_id", nullable = false, unique = true, updatable = false)
+    private Long discordId;
+
+    @OneToOne(fetch = FetchType.LAZY)
+    @MapsId
+    @JoinColumn(name = "discord_id")
+    private DiscordUser user;
+
+    @Column(name = "token", nullable = false, unique = true)
+    private String token;
+
+    public Token(long discordId) {
+        this.discordId = discordId;
+        this.token = TokenGenerator.generateToken(12);
+    }
+}

--- a/spring/src/main/java/mcserver/spring/user/repository/DiscordUserRepository.java
+++ b/spring/src/main/java/mcserver/spring/user/repository/DiscordUserRepository.java
@@ -1,0 +1,10 @@
+package mcserver.spring.user.repository;
+
+import mcserver.spring.user.model.DiscordUser;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface DiscordUserRepository extends JpaRepository<DiscordUser, Long> {
+    boolean existsDiscordUsersByDiscordId(Long discordId);
+
+    DiscordUser findByDiscordId(Long discordId);
+}

--- a/spring/src/main/java/mcserver/spring/user/repository/TokenRepository.java
+++ b/spring/src/main/java/mcserver/spring/user/repository/TokenRepository.java
@@ -1,0 +1,12 @@
+package mcserver.spring.user.repository;
+
+import mcserver.spring.user.model.Token;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface TokenRepository extends JpaRepository<Token, Long> {
+    boolean existsByDiscordId(Long discordId);
+
+    boolean existsByToken(String token);
+
+    Token findByToken(String token);
+}

--- a/spring/src/main/java/mcserver/spring/user/service/DiscordUserService.java
+++ b/spring/src/main/java/mcserver/spring/user/service/DiscordUserService.java
@@ -1,0 +1,45 @@
+package mcserver.spring.user.service;
+
+import java.util.Optional;
+import mcserver.spring.user.dto.user.UserRequest;
+import mcserver.spring.user.model.DiscordUser;
+import mcserver.spring.user.repository.DiscordUserRepository;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+public class DiscordUserService {
+    private final DiscordUserRepository userRepository;
+
+    public DiscordUserService(DiscordUserRepository userRepository) {
+        this.userRepository = userRepository;
+    }
+
+    @Transactional
+    public DiscordUser register(UserRequest request) {
+        if (this.userRepository.existsDiscordUsersByDiscordId(request.discordId())) {
+            throw new IllegalArgumentException("이미 등록된 Discord ID입니다.");
+        } else {
+            DiscordUser user = new DiscordUser();
+            user.setDiscordId(request.discordId());
+            user.setUserName(request.userName());
+            return (DiscordUser)this.userRepository.save(user);
+        }
+    }
+
+    @Transactional
+    public DiscordUser updateDiscordUser(UserRequest request) {
+        Optional<DiscordUser> existingUserOpt = this.userRepository.findById(request.discordId());
+        DiscordUser user = (DiscordUser)existingUserOpt.orElseGet(() -> this.register(request));
+        user.setUserName(request.userName());
+        user.setMinecraftName(request.minecraftName());
+        return (DiscordUser)this.userRepository.save(user);
+    }
+
+    @Transactional(
+            readOnly = true
+    )
+    public DiscordUser getById(Long id) {
+        return (DiscordUser)this.userRepository.findById(id).orElseThrow(() -> new IllegalArgumentException("해당 ID의 유저가 존재하지 않습니다."));
+    }
+}

--- a/spring/src/main/java/mcserver/spring/user/service/TokenService.java
+++ b/spring/src/main/java/mcserver/spring/user/service/TokenService.java
@@ -1,0 +1,46 @@
+package mcserver.spring.user.service;
+
+import java.time.LocalDateTime;
+import java.util.Optional;
+import mcserver.spring.user.model.DiscordUser;
+import mcserver.spring.user.model.Token;
+import mcserver.spring.user.repository.DiscordUserRepository;
+import mcserver.spring.user.repository.TokenRepository;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+public class TokenService {
+    private final TokenRepository tokenRepository;
+    private final DiscordUserRepository discordUserRepository;
+
+    public TokenService(TokenRepository tokenRepository, DiscordUserRepository discordUserRepository) {
+        this.tokenRepository = tokenRepository;
+        this.discordUserRepository = discordUserRepository;
+    }
+
+    @Transactional
+    public Token getToken(long discordId) {
+        Optional<Token> existingToken = this.tokenRepository.findById(discordId);
+        if (existingToken.isPresent()) {
+            return (Token)existingToken.get();
+        } else {
+            DiscordUser user = (DiscordUser)this.discordUserRepository.findById(discordId).orElseThrow(() -> new IllegalArgumentException("해당 유저가 존재하지 않습니다."));
+            Token token = new Token(discordId);
+            return (Token)this.tokenRepository.save(token);
+        }
+    }
+
+    @Transactional
+    public boolean isValidToken(String tokenValue) {
+        Optional<Token> token = Optional.ofNullable(this.tokenRepository.findByToken(tokenValue));
+        if (token.isEmpty()) {
+            return false;
+        } else {
+            Token existingToken = (Token)token.get();
+            LocalDateTime updatedAt = existingToken.getUpdatedAt();
+            LocalDateTime now = LocalDateTime.now();
+            return updatedAt != null && now.minusHours(1L).isBefore(updatedAt);
+        }
+    }
+}

--- a/spring/src/main/java/mcserver/spring/user/util/TokenGenerator.java
+++ b/spring/src/main/java/mcserver/spring/user/util/TokenGenerator.java
@@ -1,0 +1,15 @@
+package mcserver.spring.user.util;
+
+import java.security.SecureRandom;
+import java.util.Base64;
+
+public class TokenGenerator {
+    private static final SecureRandom secureRandom = new SecureRandom();
+    private static final Base64.Encoder base64Encoder = Base64.getUrlEncoder().withoutPadding();
+
+    public static String generateToken(int byteLength) {
+        byte[] randomBytes = new byte[byteLength];
+        secureRandom.nextBytes(randomBytes);
+        return base64Encoder.encodeToString(randomBytes);
+    }
+}


### PR DESCRIPTION

# 유저 정보 저장, 토큰 발급 검증 기능 구현

앞으로 사용하게 될 유저정보를 저장하고, 해당 유저들이 여러가지 행동을 할 수 있도록 제어하는 토큰을 발급하는 로직을 구현하였습니다.
데이터베이스는 일단 로컬에서만 사용할 예정이니 H2 데이터베이스로 간단히 구현하였습니다. JPA 사용하고 있으니 언제든지 필요해지면 MySQL 도 변경이 가능하리라 생각합니다.

이번 프로젝트는 단순한 웹 백엔드가 아니라 **마인크래프트 서버를 직접 제어하고 이벤트를 감시하는 기능**까지 포함되므로, 전통적인 Repository + Model 기반보다는 다음과 같은 계층 구조 중심으로 전개될 예정입니다:

* **RCONService**: Minecraft 서버에 실시간 명령어 전송 (`kick`, `whitelist`, `say`, `stop` 등)
* **Watchdog (Log 감시)**: 서버 로그 파일 감시 및 이벤트 기반 처리 (e.g. 유저 접속 감지, 오류 발생 시 Discord 알림 등)
* **Controller → Service → (RCON Client or Watchdog)** 흐름으로 통일된 RESTful 제어 구조 설계

이러한 구조는 마치 서버 운영 자동화 도구처럼 Spring 애플리케이션이 **외부 시스템과 직접 상호작용**하는 구조를 지향합니다.

---

## 📁 프로젝트 디렉토리 구조 요약

```
📦 root
├── docker-compose.yaml         # 전체 서비스 구성
├── README.md                   # 프로젝트 설명
├── .gitignore, .idea/          # Git 및 IDE 설정
│
├── bot/                        # 파이썬 기반 마인크래프트 봇
│   ├── Dockerfile              # 봇 컨테이너 정의
│   └── requirements.txt        # 봇 종속 패키지 목록
│
├── data/                       # 마인크래프트 서버 및 앱 데이터
│   └── readme.md
│
├── mods/                       # 마인크래프트 모드 디렉토리
│   └── readme.md
│
├── spring/                     # Spring Boot 백엔드 애플리케이션
│   ├── build.gradle            # 빌드 설정
│   ├── Dockerfile              # Spring 앱용 Dockerfile
│   ├── gradlew* / gradle/      # Gradle Wrapper 및 빌드 도구
│   ├── db/                     # H2 DB 파일 저장 위치
│   │   ├── mydb.mv.db
│   │   └── mydb.trace.db
│   ├── build/                  # Gradle 빌드 결과물 (JAR 포함)
│   │   └── libs/app.jar
│   └── src/
│       └── main/
│           ├── java/mcserver/spring/
│           │   ├── Application.java
│           │   ├── common/           # 공통 설정 및 인터셉터
│           │   ├── user/             # 유저 관련 controller, dto, model, service
│           │   ├── rcon/             # RCONClient, 명령어 처리 서비스
│           │   └── watchdog/         # 로그 감시 및 이벤트 기반 알림
│           └── resources/
│               └── application.yaml  # Spring 설정 파일
```

---
여러가지 디렉토리들이 있지만 사실 Docker-Compsoe 설정으로 자신과 관련이 있는 디렉토리에서만 작업하게 됩니다. 예를 들어 Spring 은 spring, mods, data 만 접근하고 bot 은 자기 자신을 제외한 디렉토리에는 접근하지 않습니다.


## 🔧 주요 구성 요소

* **`docker-compose.yaml`**
  → Minecraft 서버, Python 봇, Spring 백엔드 컨테이너 정의
* **`spring/`**
  → Spring Boot 애플리케이션 소스 및 빌드 파일
* **`bot/`**
  → Minecraft 연동 Python 봇, `/app/main.py` 실행
* **`mods/` & `data/`**
  → Minecraft 서버에 마운트되는 외부 디렉토리
* **`spring/src/...`**
  → 유저 인증, 토큰 발급, RCON 제어 및 로그 감시 기능 포함

---

PR은 spring 내부에서 기능 단위로 정리하고, 단계가 완료될 때마다 별도의 PR로 나눠서 공유할 예정입니다.
RCON 제어와 로그 감시 기능은 각각 분리된 모듈로 관리될 예정이며, 향후에는 Discord 알림, 서버 상태 API, 명령 히스토리 기록 등으로 확장할 수 있습니다.
